### PR TITLE
refactor(api): Refine Core API and Encapsulate Key Conversion Logic

### DIFF
--- a/Sources/PactKitCore/Common/Pact+Error.swift
+++ b/Sources/PactKitCore/Common/Pact+Error.swift
@@ -58,6 +58,7 @@ extension Pact.Error {
     case keyCreationFromDataFailed
     case encryptionFailed(reason: String)
     case decryptionFailed(reason: String)
+    case invalidKeySize(expected: Int, actual: Int)
 
     public var errorDescription: String? {
       switch self {
@@ -67,6 +68,8 @@ extension Pact.Error {
         return "Encryption failed. Reason: \(reason)"
       case .decryptionFailed(let reason):
         return "Decryption failed. This may be due to data corruption, tampering, or an incorrect key. Reason: \(reason)"
+      case .invalidKeySize(let expected, let actual):
+        return "Invalid key size. Expected \(expected) bytes, but received \(actual) bytes."
       }
     }
   }

--- a/Sources/PactKitCore/Crypto/CryptoOperationResult.swift
+++ b/Sources/PactKitCore/Crypto/CryptoOperationResult.swift
@@ -1,0 +1,19 @@
+//
+//  CryptoOperationResult.swift
+//  PactKit
+//
+//  Created by Geonhee on 8/15/25.
+//
+
+import Foundation
+
+/// A structure that encapsulates the result of a cryptographic operation performed by `P256PublicKeyConverter`.
+/// It contains the result of the operation itself, along with the response key formatted for the counterpart.
+public struct CryptoOperationResult<T> {
+  /// The public key data formatted to be sent back to the counterpart,
+  /// matching the counterpart's original key format (prefixed or not).
+  public let responseKeyData: Data
+
+  /// The generic result payload from the cryptographic operation that was executed.
+  public let result: T
+}

--- a/Sources/PactKitCore/Crypto/P256PublicKeyConverter.swift
+++ b/Sources/PactKitCore/Crypto/P256PublicKeyConverter.swift
@@ -1,0 +1,65 @@
+//
+//  P256PublicKeyConverter.swift
+//  PactKit
+//
+//  Created by Geonhee on 8/15/25.
+//
+
+import CryptoKit
+import Foundation
+
+/// A utility to perform cryptographic operations with P-256 public keys,
+/// handling interoperability between CryptoKit and other formats (e.g., SubtleCrypto).
+public struct P256PublicKeyConverter {
+
+    public static let uncompressedKeyPrefix: UInt8 = 0x04
+    public static let keySizeWithoutPrefix = 64
+
+    /// Converts raw key data (potentially with a prefix) into the 64-byte format required by CryptoKit.
+    public func formatForCryptoKit(from rawData: Data) throws -> Data {
+        var keyData = rawData
+        if keyData.first == Self.uncompressedKeyPrefix {
+            keyData = keyData.dropFirst()
+        }
+        guard keyData.count == Self.keySizeWithoutPrefix else {
+            throw Pact.Error.cryptoError(.invalidKeySize(expected: Self.keySizeWithoutPrefix, actual: keyData.count))
+        }
+        return keyData
+    }
+
+    /// Formats a 64-byte CryptoKit key for export, respecting the original format of a counterpart's key.
+    public func formatForExport(from cryptoKitData: Data, basedOn originalData: Data) -> Data {
+        let counterpartHadPrefix = (originalData.first == Self.uncompressedKeyPrefix && originalData.count == Self.keySizeWithoutPrefix + 1)
+
+        guard cryptoKitData.count == Self.keySizeWithoutPrefix else {
+            return cryptoKitData // Should not happen with valid CryptoKit data.
+        }
+
+        if counterpartHadPrefix {
+            var exportData = Data([Self.uncompressedKeyPrefix])
+            exportData.append(cryptoKitData)
+            return exportData
+        } else {
+            return cryptoKitData
+        }
+    }
+
+    /// Performs a given operation atomically, handling all key format conversions.
+    public func perform<T>(
+        with counterpartKeyData: Data,
+        operation: (_ cryptoKitKey: P256.KeyAgreement.PublicKey) throws -> (responseKey: P256.KeyAgreement.PublicKey, result: T)
+    ) throws -> CryptoOperationResult<T> {
+
+        let keyForImport = try formatForCryptoKit(from: counterpartKeyData)
+        let counterpartPublicKey = try P256.KeyAgreement.PublicKey(rawRepresentation: keyForImport)
+
+        let (responseKey, operationResult) = try operation(counterpartPublicKey)
+
+        let responseKeyData = formatForExport(from: responseKey.rawRepresentation, basedOn: counterpartKeyData)
+
+        return CryptoOperationResult(
+            responseKeyData: responseKeyData,
+            result: operationResult
+        )
+    }
+}

--- a/Sources/PactKitCore/Crypto/P256PublicKeyConverter.swift
+++ b/Sources/PactKitCore/Crypto/P256PublicKeyConverter.swift
@@ -12,54 +12,54 @@ import Foundation
 /// handling interoperability between CryptoKit and other formats (e.g., SubtleCrypto).
 public struct P256PublicKeyConverter {
 
-    public static let uncompressedKeyPrefix: UInt8 = 0x04
-    public static let keySizeWithoutPrefix = 64
+  public static let uncompressedKeyPrefix: UInt8 = 0x04
+  public static let keySizeWithoutPrefix = 64
 
-    /// Converts raw key data (potentially with a prefix) into the 64-byte format required by CryptoKit.
-    public func formatForCryptoKit(from rawData: Data) throws -> Data {
-        var keyData = rawData
-        if keyData.first == Self.uncompressedKeyPrefix {
-            keyData = keyData.dropFirst()
-        }
-        guard keyData.count == Self.keySizeWithoutPrefix else {
-            throw Pact.Error.cryptoError(.invalidKeySize(expected: Self.keySizeWithoutPrefix, actual: keyData.count))
-        }
-        return keyData
+  /// Converts raw key data (potentially with a prefix) into the 64-byte format required by CryptoKit.
+  public func formatForCryptoKit(from rawData: Data) throws -> Data {
+    var keyData = rawData
+    if keyData.first == Self.uncompressedKeyPrefix {
+      keyData = keyData.dropFirst()
+    }
+    guard keyData.count == Self.keySizeWithoutPrefix else {
+      throw Pact.Error.cryptoError(.invalidKeySize(expected: Self.keySizeWithoutPrefix, actual: keyData.count))
+    }
+    return keyData
+  }
+
+  /// Formats a 64-byte CryptoKit key for export, respecting the original format of a counterpart's key.
+  public func formatForExport(from cryptoKitData: Data, basedOn originalData: Data) -> Data {
+    let counterpartHadPrefix = (originalData.first == Self.uncompressedKeyPrefix && originalData.count == Self.keySizeWithoutPrefix + 1)
+
+    guard cryptoKitData.count == Self.keySizeWithoutPrefix else {
+      return cryptoKitData // Should not happen with valid CryptoKit data.
     }
 
-    /// Formats a 64-byte CryptoKit key for export, respecting the original format of a counterpart's key.
-    public func formatForExport(from cryptoKitData: Data, basedOn originalData: Data) -> Data {
-        let counterpartHadPrefix = (originalData.first == Self.uncompressedKeyPrefix && originalData.count == Self.keySizeWithoutPrefix + 1)
-
-        guard cryptoKitData.count == Self.keySizeWithoutPrefix else {
-            return cryptoKitData // Should not happen with valid CryptoKit data.
-        }
-
-        if counterpartHadPrefix {
-            var exportData = Data([Self.uncompressedKeyPrefix])
-            exportData.append(cryptoKitData)
-            return exportData
-        } else {
-            return cryptoKitData
-        }
+    if counterpartHadPrefix {
+      var exportData = Data([Self.uncompressedKeyPrefix])
+      exportData.append(cryptoKitData)
+      return exportData
+    } else {
+      return cryptoKitData
     }
+  }
 
-    /// Performs a given operation atomically, handling all key format conversions.
-    public func perform<T>(
-        with counterpartKeyData: Data,
-        operation: (_ cryptoKitKey: P256.KeyAgreement.PublicKey) throws -> (responseKey: P256.KeyAgreement.PublicKey, result: T)
-    ) throws -> CryptoOperationResult<T> {
+  /// Performs a given operation atomically, handling all key format conversions.
+  public func perform<T>(
+    with counterpartKeyData: Data,
+    operation: (_ cryptoKitKey: P256.KeyAgreement.PublicKey) throws -> (responseKey: P256.KeyAgreement.PublicKey, result: T)
+  ) throws -> CryptoOperationResult<T> {
 
-        let keyForImport = try formatForCryptoKit(from: counterpartKeyData)
-        let counterpartPublicKey = try P256.KeyAgreement.PublicKey(rawRepresentation: keyForImport)
+    let keyForImport = try formatForCryptoKit(from: counterpartKeyData)
+    let counterpartPublicKey = try P256.KeyAgreement.PublicKey(rawRepresentation: keyForImport)
 
-        let (responseKey, operationResult) = try operation(counterpartPublicKey)
+    let (responseKey, operationResult) = try operation(counterpartPublicKey)
 
-        let responseKeyData = formatForExport(from: responseKey.rawRepresentation, basedOn: counterpartKeyData)
+    let responseKeyData = formatForExport(from: responseKey.rawRepresentation, basedOn: counterpartKeyData)
 
-        return CryptoOperationResult(
-            responseKeyData: responseKeyData,
-            result: operationResult
-        )
-    }
+    return CryptoOperationResult(
+      responseKeyData: responseKeyData,
+      result: operationResult
+    )
+  }
 }

--- a/Sources/PactKitCore/Host/Pact+Host.swift
+++ b/Sources/PactKitCore/Host/Pact+Host.swift
@@ -5,6 +5,7 @@
 //  Created by Geonhee on 8/12/25.
 //
 
+import CryptoKit
 import Foundation
 
 extension Pact {
@@ -13,7 +14,12 @@ extension Pact {
   public final class Host {
 
     /// The permanent identity of this Host, used for signing operations.
-    public let identity: Identity
+    private let identity: Identity
+
+    /// The public part of the identity key, which can be shared with counterparts for signature verification.
+    public var identityPublicKey: Curve25519.Signing.PublicKey {
+      identity.publicKey
+    }
 
     /// Initializes a new Host instance.
     ///
@@ -23,6 +29,13 @@ extension Pact {
     ///   Defaults to a standard `KeychainStore`.
     public init(identityStore: any SecureKeyStoring = KeychainStore()) throws {
       self.identity = try Identity(keyStore: identityStore)
+    }
+
+    /// Signs the given data with the Host's permanent identity private key.
+    /// - Parameter data: The data to be signed.
+    /// - Returns: The signature for the given data.
+    public func signature(for data: Data) throws -> Data {
+      return try identity.privateKey.signature(for: data)
     }
   }
 }

--- a/Tests/PactKitCoreTests/Channel/PactHostChannelTests.swift
+++ b/Tests/PactKitCoreTests/Channel/PactHostChannelTests.swift
@@ -26,7 +26,7 @@ struct PactHostChannelTests {
     "Establishes a symmetric channel and enables E2E encryption (prefixed key)",
     .tags(.integration, .channel, .symmetric)
   )
-  func channelEstablishmentWithPrefix() throws {
+  func successfulChannelEstablishmentWithPrefix() throws {
     // Arrange: Simulate a counterpart with its own Host instance and a prefixed key.
     // A real counterpart would be on another device, but for testing, we can simulate it with another Host.
     let counterpartPrivateKey = P256.KeyAgreement.PrivateKey()
@@ -56,7 +56,7 @@ struct PactHostChannelTests {
     "Establishes a symmetric channel and enables E2E encryption (raw key)",
     .tags(.integration, .channel, .symmetric)
   )
-  func channelEstablishmentWithoutPrefix() throws {
+  func successfulChannelEstablishmentWithoutPrefix() throws {
     // Arrange: Simulate a counterpart sending a raw 64-byte key.
     let counterpartPrivateKey = P256.KeyAgreement.PrivateKey()
     let counterpartKeyForExport = counterpartPrivateKey.publicKey.rawRepresentation
@@ -74,6 +74,20 @@ struct PactHostChannelTests {
     )
 
     try assertCommunication(between: hostChannel, and: counterpartChannel)
+  }
+
+  @Test(
+    "Establish channel should throw invalidKeySize error for incorrectly sized keys",
+    .tags(.integration, .channel, .errorHandling)
+  )
+  func channelEstablishmentFailsWithInvalidKeySize() throws {
+    // Arrange: Simulate a counterpart sending a key with an invalid size (e.g., 62 bytes).
+    let invalidKeyData = Data(repeating: 0x01, count: 62)
+
+    // Act & Assert: Expect the specific error to be thrown.
+    #expect(throws: Pact.Error.self) {
+      _ = try host.establishChannel(with: invalidKeyData)
+    }
   }
 
   // MARK: - Test Helpers

--- a/Tests/PactKitCoreTests/Channel/PactHostChannelTests.swift
+++ b/Tests/PactKitCoreTests/Channel/PactHostChannelTests.swift
@@ -5,8 +5,9 @@
 //  Created by Geonhee on 8/12/25.
 //
 
-import CryptoKit
 import Testing
+import CryptoKit
+import Foundation
 
 @testable import PactKitCore
 
@@ -14,6 +15,7 @@ import Testing
 struct PactHostChannelTests {
 
   var host: Pact.Host!
+  let converter = P256PublicKeyConverter()
 
   init() throws {
     let mockKeyStore = MockKeyStore()
@@ -21,45 +23,100 @@ struct PactHostChannelTests {
   }
 
   @Test(
-    "A secure channel can be successfully established with a valid counterpart",
-    .tags(.integration, .channel, .happyPath)
+    "Establishes a symmetric channel and enables E2E encryption (prefixed key)",
+    .tags(.integration, .channel, .symmetric)
   )
-  func successfulChannelEstablishment() throws {
-    // Simulate a counterpart by creating its own ephemeral key pair.
-    let counterpartEphemeralPrivateKey = P256.KeyAgreement.PrivateKey()
-    let counterpartEphemeralPublicKey = counterpartEphemeralPrivateKey.publicKey
-    let handshakeRequest = Pact.HandshakeRequest(ephemeralPublicKey: counterpartEphemeralPublicKey.rawRepresentation)
+  func channelEstablishmentWithPrefix() throws {
+    // Arrange: Simulate a counterpart with its own Host instance and a prefixed key.
+    // A real counterpart would be on another device, but for testing, we can simulate it with another Host.
+    let counterpartPrivateKey = P256.KeyAgreement.PrivateKey()
+    var counterpartKeyForExport = Data([0x04])
+    counterpartKeyForExport.append(counterpartPrivateKey.publicKey.rawRepresentation)
 
-    // The Host processes the request and establishes its side of the channel.
-    let (hostChannel, handshakeResponse) = try host.establishChannel(with: handshakeRequest)
+    // Act
+    let (hostChannel, handshakeResponse) = try host.establishChannel(with: counterpartKeyForExport)
 
-    // The counterpart validates the response and establishes its side.
+    // Assert: The response key format should be symmetric.
+    #expect(handshakeResponse.ephemeralPublicKey.count == 65)
 
-    // 1. The counterpart computes the same shared secret.
-    let hostEphemeralPublicKey = try P256.KeyAgreement.PublicKey(rawRepresentation: handshakeResponse.ephemeralPublicKey)
-    let counterpartSharedSecret = try counterpartEphemeralPrivateKey.sharedSecretFromKeyAgreement(with: hostEphemeralPublicKey)
+    // Act (Counterpart side): The counterpart uses the response to establish its own channel.
+    // For this test, we simulate this by calling a hypothetical `counterpart.establishChannel`
+    // or by manually performing the final steps. Let's create the counterpart's channel manually.
+    let (counterpartChannel, _) = try createCounterpartChannel(
+      privateKey: counterpartPrivateKey,
+      hostResponse: handshakeResponse,
+      hostIdentityPublicKey: host.identityPublicKey
+    )
 
-    // 2. The counterpart derives the same session key using the identical HKDF parameters.
-    let counterpartSessionKey = counterpartSharedSecret.hkdfDerivedSymmetricKey(
+    // Assert: The two channels can communicate.
+    try assertCommunication(between: hostChannel, and: counterpartChannel)
+  }
+
+  @Test(
+    "Establishes a symmetric channel and enables E2E encryption (raw key)",
+    .tags(.integration, .channel, .symmetric)
+  )
+  func channelEstablishmentWithoutPrefix() throws {
+    // Arrange: Simulate a counterpart sending a raw 64-byte key.
+    let counterpartPrivateKey = P256.KeyAgreement.PrivateKey()
+    let counterpartKeyForExport = counterpartPrivateKey.publicKey.rawRepresentation
+
+    // Act
+    let (hostChannel, handshakeResponse) = try host.establishChannel(with: counterpartKeyForExport)
+
+    // Assert: The response key format should be symmetric.
+    #expect(handshakeResponse.ephemeralPublicKey.count == 64)
+
+    let (counterpartChannel, _) = try createCounterpartChannel(
+      privateKey: counterpartPrivateKey,
+      hostResponse: handshakeResponse,
+      hostIdentityPublicKey: host.identityPublicKey
+    )
+
+    try assertCommunication(between: hostChannel, and: counterpartChannel)
+  }
+
+  // MARK: - Test Helpers
+
+  /// Simulates the final steps a counterpart would take to create its own channel after receiving a response.
+  private func createCounterpartChannel(
+    privateKey: P256.KeyAgreement.PrivateKey,
+    hostResponse: Pact.HandshakeResponse,
+    hostIdentityPublicKey: Curve25519.Signing.PublicKey
+  ) throws -> (channel: Pact.Channel, transcript: Data) {
+    let hostKeyForImport = try converter.formatForCryptoKit(from: hostResponse.ephemeralPublicKey)
+    let hostEphemeralPublicKey = try P256.KeyAgreement.PublicKey(rawRepresentation: hostKeyForImport)
+
+    let counterpartKeyForTranscript = privateKey.publicKey.rawRepresentation
+
+    let transcript = hostEphemeralPublicKey.rawRepresentation + counterpartKeyForTranscript
+
+    let isSignatureValid = hostIdentityPublicKey.isValidSignature(hostResponse.signature, for: transcript)
+    #expect(isSignatureValid, "Signature from the Host must be valid.")
+
+    let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: hostEphemeralPublicKey)
+    let sessionKey = sharedSecret.hkdfDerivedSymmetricKey(
       using: SHA256.self,
       salt: "PactKit-Channel-Establishment-Salt".data(using: .utf8)!,
-      sharedInfo: hostEphemeralPublicKey.rawRepresentation + counterpartEphemeralPublicKey.rawRepresentation,
+      sharedInfo: transcript,
       outputByteCount: 32
     )
 
-    // 3. The counterpart verifies the signature using the Host's public identity key.
-    let transcript = hostEphemeralPublicKey.rawRepresentation + counterpartEphemeralPublicKey.rawRepresentation
-    let isSignatureValid = host.identity.publicKey.isValidSignature(handshakeResponse.signature, for: transcript)
-    #expect(isSignatureValid, "The signature from the Host must be valid.")
+    return (Pact.Channel(sessionKey: sessionKey), transcript)
+  }
 
-    // 4. Finally, test end-to-end encryption to prove the session keys match.
+  /// Asserts that two channels can successfully encrypt and decrypt a message.
+  private func assertCommunication(between channelA: Pact.Channel, and channelB: Pact.Channel) throws {
     let originalMessage = "Hello, PactKit! This is a secure channel."
-    let encryptedData = try hostChannel.encrypt(message: originalMessage)
 
-    // Create a temporary channel for the counterpart with its derived key.
-    let counterpartChannel = Pact.Channel(sessionKey: counterpartSessionKey)
-    let decryptedMessage = try counterpartChannel.decrypt(encryptedData: encryptedData)
+    // A -> B
+    let encryptedFromA = try channelA.encrypt(message: originalMessage)
+    let decryptedByB = try channelB.decrypt(encryptedData: encryptedFromA)
+    #expect(decryptedByB == originalMessage)
 
-    #expect(decryptedMessage == originalMessage, "The decrypted message must match the original.")
+    // B -> A
+    let encryptedFromB = try channelB.encrypt(message: originalMessage)
+    let decryptedByA = try channelA.decrypt(encryptedData: encryptedFromB)
+    #expect(decryptedByA == originalMessage)
   }
 }

--- a/Tests/PactKitCoreTests/Crypto/P256PublicKeyConverterTests.swift
+++ b/Tests/PactKitCoreTests/Crypto/P256PublicKeyConverterTests.swift
@@ -1,0 +1,98 @@
+//
+//  P256PublicKeyConverterTests.swift
+//  PactKit
+//
+//  Created by Geonhee on 8/15/25.
+//
+
+import Foundation
+import Testing
+
+@testable import PactKitCore
+
+@Suite("P256PublicKeyConverter Tests")
+struct P256PublicKeyConverterTests {
+
+  let converter = P256PublicKeyConverter()
+
+  static let raw64ByteKey = Data(repeating: 0x01, count: 64)
+  static let raw65ByteKeyWithPrefix = Data([0x04]) + Data(repeating: 0x01, count: 64)
+
+  @Test(
+    "formatForCryptoKit should strip the 0x04 prefix from a 65-byte key",
+    .tags(.unit, .crypto, .happyPath)
+  )
+  func formatForCryptoKitStripsPrefix() throws {
+    let result = try converter.formatForCryptoKit(from: Self.raw65ByteKeyWithPrefix)
+
+    // Assert
+    #expect(result.count == 64)
+    #expect(result == Self.raw64ByteKey)
+  }
+
+  @Test(
+    "formatForCryptoKit should pass through a 64-byte key unmodified",
+    .tags(.unit, .crypto, .happyPath)
+  )
+  func formatForCryptoKitAccepts64ByteKey() throws {
+    let result = try converter.formatForCryptoKit(from: Self.raw64ByteKey)
+
+    // Assert
+    #expect(result.count == 64)
+    #expect(result == Self.raw64ByteKey)
+  }
+
+  @Test(
+    "formatForCryptoKit should throw an error for keys of invalid size",
+    .tags(.unit, .crypto, .errorHandling)
+  )
+  func formatForCryptoKitThrowsErrorForInvalidSize() throws {
+    // Arrange
+    let invalidKey = Data(repeating: 0x01, count: 63)
+
+    // Act & Assert
+    #expect(throws: Pact.Error.self) {
+      _ = try converter.formatForCryptoKit(from: invalidKey)
+    }
+  }
+
+  @Test(
+    "formatForExport should prepend prefix when original data had a prefix",
+    .tags(.unit, .crypto, .symmetric)
+  )
+  func formatForExportIsSymmetricWithPrefix() {
+    // Arrange
+    let originalDataFromCounterpart = Self.raw65ByteKeyWithPrefix
+    let keyToSendBack = Self.raw64ByteKey
+
+    // Act: Call the method with the new signature.
+    let result = converter.formatForExport(
+      from: keyToSendBack,
+      basedOn: originalDataFromCounterpart
+    )
+
+    // Assert: The result should be 65 bytes, matching the original format.
+    #expect(result.count == 65)
+    #expect(result == Self.raw65ByteKeyWithPrefix)
+  }
+
+  @Test(
+    "formatForExport should NOT prepend prefix when original data was raw",
+    .tags(.unit, .crypto, .symmetric)
+  )
+  func formatForExportIsSymmetricWithoutPrefix() {
+    // Arrange
+    let originalDataFromCounterpart = Self.raw64ByteKey
+    let keyToSendBack = Self.raw64ByteKey
+
+    // Act
+    let result = converter.formatForExport(
+      from: keyToSendBack,
+      basedOn: originalDataFromCounterpart
+    )
+
+    // Assert: The result should be 64 bytes, matching the original format.
+    #expect(result.count == 64)
+    #expect(result == Self.raw64ByteKey)
+  }
+}

--- a/Tests/PactKitCoreTests/Support/Testing+Tags.swift
+++ b/Tests/PactKitCoreTests/Support/Testing+Tags.swift
@@ -15,8 +15,10 @@ extension Tag {
 
   // MARK: Feature Area
   @Tag static var channel: Self
+  @Tag static var crypto: Self
   @Tag static var identity: Self
   @Tag static var keychain: Self
+  @Tag static var symmetric: Self
 
   // MARK: Scenario
   @Tag static var happyPath: Self


### PR DESCRIPTION
## Description

This PR introduces a significant refinement of the `PactKitCore` public API and internal structure. The changes are based on our core principles of improving developer experience, clarity, and long-term maintainability by creating a more robust and intuitive interface.

---

## Key Changes & Design Decisions

### API Refinements
- **Improved `Pact.Host` Encapsulation:** The internal `identity` object is no longer public. Instead, a clean `identityPublicKey` of type `Curve25519.Signing.PublicKey` is provided. This simplifies usage for consumers who need to perform signature verifications, as they no longer need to deal with raw `Data`.
- **Simplified `establishChannel` Method:** The method signature was changed to accept raw `Data` for the counterpart's key, decoupling the method from a specific request struct and making the API more direct and flexible.

### Structural Improvements
- **`P256PublicKeyConverter` Utility:** A new `P256PublicKeyConverter` struct has been introduced to handle the complex task of converting P-256 public key formats. It features an atomic `perform` method that manages the entire conversion lifecycle, respecting the counterpart's original key format (prefixed or not) in its response. This encapsulates a tricky piece of interoperability logic.
- **`CryptoOperationResult` Return Type:** The converter now returns a dedicated `CryptoOperationResult<T>` struct instead of a complex tuple, making the return value self-documenting and more extensible.

### Testing
- **New Unit Tests:** A comprehensive test suite (`P256PublicKeyConverterTests`) has been added to validate the new key converter.
- **Updated Integration Tests:** The `PactHostChannelTests` suite has been updated to reflect the new API and now includes symmetric testing for both prefixed (65-byte) and non-prefixed (64-byte) keys from the counterpart.